### PR TITLE
Build release binaries on github actions

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -10,6 +10,13 @@ jobs:
         - macos-latest
         - ubuntu-latest
         - windows-latest
+        include:
+        - os: ubuntu-latest
+          target: x86_64-unknown-linux-musl
+        - os: macos-latest
+          target: x86_64-apple-darwin
+        - os: windows-latest
+          target: x86_64-pc-windows-msvc
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v2
@@ -33,3 +40,17 @@ jobs:
       run: cargo clippy
     - name: Format
       run: cargo fmt -- --check
+    - name: Package
+      id: package
+      if: startsWith(github.ref, 'refs/tags/')
+      run: ./bin/package ${{github.ref}} ${{matrix.os}} ${{matrix.target}}
+      shell: bash
+    - name: Publish
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        draft: false
+        files: ${{steps.package.outputs.archive}}
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -1,15 +1,34 @@
 # qc
 
-```
-$ cargo install qc
-```
-
 qc (short for quick calc) is an enhanced Reverse Polish notation (RPN) command line tool designed to assist with quick and dirty calcs.
-
 
 qc offers enhancements to a traditional RPN calculator including the use of a `:` before all operators that pops all items before it off the stack, performs the operation, and pushes the result onto the stack. Examples are included below.
 
+## Installation
+
+### Pre-built binaries
+
+Pre-built binaries for Linux, macOS, and Windows can be found on
+[the releases page](https://github.com/rrybarczyk/qc/releases).
+
+You can use the following command to download the latest binary for Linux,
+MacOS or Windows, just replace `DEST` with the directory where you'd like to
+install the `qc` binary:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSf \
+  https://raw.githubusercontent.com/rrybarczyk/qc/master/bin/install \
+  | bash -s -- --to DEST
+```
+
+### Cargo
+
+`qc` is written in [Rust](https://www.rust-lang.org/) and can be built from
+source and installed with `cargo install qc`. To get Rust, use the
+[rustup installer](https://rustup.rs/).
+
 ## Operations
+
 ### Binary Operators
 - `add`     pops the top two items off the stack, adds them, and pushes the sum onto the stack
 - `sub`     pops the top two items off the stack, subtracts them, and pushes the difference onto the stack
@@ -28,8 +47,8 @@ qc offers enhancements to a traditional RPN calculator including the use of a `:
 #### Addition
 ```
 $ qc 1 2 add
-Script                  Stack                   Details 
-                                        
+Script                  Stack                   Details
+
                         [ ]
 1                       [ 1 ]
 2                       [ 1 2 ]
@@ -37,7 +56,7 @@ add                     [ 3 ]                   1 + 2
 
 
 $ qc 1 2 3 add add
-Script                  Stack                   Details 
+Script                  Stack                   Details
                         [ ]
 1                       [ 1 ]
 2                       [ 1 2 ]
@@ -48,15 +67,15 @@ add                     [ 6 ]                    1 + 5
 
 #### Subtraction
 ```
-$ qc 1 2 sub            
-Script                  Stack                   Details 
+$ qc 1 2 sub
+Script                  Stack                   Details
                         [ ]
 1                       [ 1 ]
 2                       [ 1 2 ]
 sub                     [ -1 ]                  1 - 2
 
 $ qc 1 2 3 sub sub
-Script                  Stack                   Details 
+Script                  Stack                   Details
                         [ ]
 1                       [ 1 ]
 2                       [ 1 2 ]
@@ -68,8 +87,8 @@ sub                     [ 2 ]                   1 - -1
 #### Multiplication
 ```
 $ qc 1 2 mul
-Script                  Stack                   Details 
-                                        
+Script                  Stack                   Details
+
                         [ ]
 1                       [ 1 ]
 2                       [ 1 2 ]
@@ -77,7 +96,7 @@ mul                     [ 2 ]                   1 * 2
 
 
 $ qc 1 2 3 mul mul
-Script                  Stack                   Details 
+Script                  Stack                   Details
                         [ ]
 1                       [ 1 ]
 2                       [ 1 2 ]
@@ -89,8 +108,8 @@ mul                     [ 6 ]                   1 * 6
 #### Division
 ```
 $ qc 3 9 div
-Script                  Stack                   Details 
-                                        
+Script                  Stack                   Details
+
                         [ ]
 3                       [ 3 ]
 9                       [ 3 9 ]
@@ -98,7 +117,7 @@ div                     [ 0.5 ]                 3 / 9
 
 
 $ qc 1 2 3 div div
-Script                  Stack                   Details 
+Script                  Stack                   Details
                         [ ]
 1                       [ 1 ]
 2                       [ 1 2 ]
@@ -111,7 +130,7 @@ div                     [ 6 ]                   6 * 1
 
 ```
 $ qc 4 7 9 add 2 8 mul mul mul
-Script                  Stack                   Details 
+Script                  Stack                   Details
 4                       [ 4 ]
 7                       [ 4 7 ]
 9                       [ 4 7 9 ]
@@ -125,7 +144,7 @@ mul                     [ 1024 ]                4 * 256
 
 ```
 $ qc 4 7 9 add 2 8 mul mul 4 div sub
-Script                  Stack                   Details 
+Script                  Stack                   Details
 4                       [ 4 ]
 7                       [ 4 7 ]
 9                       [ 4 7 9 ]
@@ -141,7 +160,7 @@ sub                     [ -60 ]                 4 - 64
 
 ```
 $ qc 4 7 9 add add  2 3 5 mul mul mul 1 1 sub sub 20 5 div div .
-Script                  Stack                   Details 
+Script                  Stack                   Details
 4                       [ 4 ]
 7                       [ 4 7 ]
 9                       [ 4 7 9 ]
@@ -162,13 +181,13 @@ sub                     [ 600 ]                 600 - 0
 div                     [ 600 4 ]               20 / 5
 div                     [ 150 ]                 600 / 4
 
-> dec: 150        hex: 0x96          oct: o226        bin: b10010110 
+> dec: 150        hex: 0x96          oct: o226        bin: b10010110
 ```
 
 ### Enhanced RPN Capabilities
 ```
 $ qc 4 7 9 :add 2 3 5 :mul 1 1 :sub 20 5 :div .
-Script                  Stack                   Details 
+Script                  Stack                   Details
 4                       [ 4 ]
 7                       [ 4 7 ]
 9                       [ 4 7 9 ]
@@ -184,7 +203,7 @@ Script                  Stack                   Details
 5                       [ 600 20 5 ]
 :div                    [ 150 ]                 600 / (20 / 5)
 
-> dec: 150        hex: 0x96          oct: o226        bin: b10010110 
+> dec: 150        hex: 0x96          oct: o226        bin: b10010110
 
 $ qc 0xa xb o22 b1101 :.
 > dec: 13         hex: 0xd           oct: o15         bin: b1101

--- a/bin/install
+++ b/bin/install
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+set -eu
+
+help() {
+  cat <<'EOF'
+Install a binary release of a qc hosted on GitHub
+
+Usage:
+    install [options]
+
+Options:
+    -h, --help      Display this message
+    -f, --force     Force overwriting an existing binary
+    --tag TAG       Tag (version) of the crate to install (default <latest release>)
+    --to LOCATION   Where to install the binary (default ~/.cargo/bin)
+EOF
+}
+
+git=rrybarczyk/qc
+crate=qc
+url=https://github.com/rrybarczyk/qc
+releases=$url/releases
+
+case `uname -s` in
+  Darwin) target=x86_64-apple-darwin;;
+  Linux)  target=x86_64-unknown-linux-musl;;
+  *)      target=x86_64-pc-windows-msvc;;
+esac
+
+say() {
+  echo "install: $1"
+}
+
+say_err() {
+  say "$1" >&2
+}
+
+err() {
+  if [ ! -z ${td-} ]; then
+    rm -rf $td
+  fi
+
+  say_err "ERROR $1"
+  exit 1
+}
+
+need() {
+  if ! command -v $1 > /dev/null 2>&1; then
+    err "need $1 (command not found)"
+  fi
+}
+
+force=false
+while test $# -gt 0; do
+  case $1 in
+    --force | -f)
+      force=true
+      ;;
+    --help | -h)
+      help
+      exit 0
+      ;;
+    --tag)
+      tag=$2
+      shift
+      ;;
+    --to)
+      dest=$2
+      shift
+      ;;
+    *)
+      ;;
+  esac
+  shift
+done
+
+# Dependencies
+need basename
+need curl
+need install
+need mkdir
+need mktemp
+need tar
+
+# Optional dependencies
+if [ -z ${tag-} ]; then
+  need cut
+  need rev
+fi
+
+if [ -z ${dest-} ]; then
+  dest="$HOME/.cargo/bin"
+fi
+
+if [ -z ${tag-} ]; then
+  tag=$(curl -s "$releases/latest" | cut -d'"' -f2 | rev | cut -d'/' -f1 | rev)
+fi
+
+archive="$releases/download/$tag/$crate-$tag-$target.tar.gz"
+
+say_err "Repository:  $url"
+say_err "Crate:       $crate"
+say_err "Tag:         $tag"
+say_err "Target:      $target"
+say_err "Destination: $dest"
+say_err "Archive:     $archive"
+
+td=$(mktemp -d || mktemp -d -t tmp)
+curl -sL $archive | tar -C $td -xz
+
+for f in $(ls $td); do
+  test -x $td/$f || continue
+
+  if [ -e "$dest/$f" ] && [ $force = false ]; then
+    err "$f already exists in $dest"
+  else
+    mkdir -p $dest
+    install -m 755 $td/$f $dest
+  fi
+done
+
+rm -rf $td

--- a/bin/package
+++ b/bin/package
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+tag=${1#"refs/tags/"}
+os=$2
+target=$3
+src=`pwd`
+dist=$src/dist
+bin=qc
+
+echo "Packaging $bin $tag for $target..."
+
+test -f Cargo.lock || cargo generate-lockfile
+
+echo "Building $bin..."
+
+case $os in
+  ubuntu-latest | macos-latest)
+    cargo rustc --bin $bin --target $target --release -- -C lto
+    executable=target/$target/release/$bin
+    ;;
+  windows-latest)
+    cargo rustc --bin $bin --target $target --release -- -C lto -C target-feature="+crt-static"
+    executable=target/$target/release/$bin.exe
+    ;;
+esac
+
+echo "Copying release files..."
+mkdir dist
+cp \
+  $executable \
+  Cargo.lock \
+  Cargo.toml \
+  LICENSE \
+  README.md \
+  $dist
+
+cd $dist
+echo "Creating release archive..."
+case $os in
+  ubuntu-latest | macos-latest)
+    archive=$dist/$bin-$tag-$target.tar.gz
+    tar czf $archive *
+    echo "::set-output name=archive::$archive"
+    ;;
+  windows-latest)
+    archive=$dist/$bin-$tag-$target.zip
+    7z a $archive *
+    echo "::set-output name=archive::`pwd -W`/$bin-$tag-$target.zip"
+    ;;
+esac


### PR DESCRIPTION
Adds `Package` and `Publish` steps to the main GitHub Actions workflow
to build release archives and publish them to the releases page whenever
a tag is pushed to the repository.

The `bin/package` script builds the archives, and `bin/install` provides
a  handy way to install those archives.

Also adds instructions for how to use the install script to the readme.