### PR TITLE
Cache build artifacts

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,6 +1,14 @@
 name: Rust
 
-on: [push]
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - v*.*.*
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:
@@ -20,6 +28,25 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v2
+
+    - name: Cache cargo registry
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/registry
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Cache cargo index
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/git
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Cache cargo build
+      uses: actions/cache@v1
+      with:
+        path: target
+        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
     - name: Install
       uses: actions-rs/toolchain@v1
       with:
@@ -27,24 +54,31 @@ jobs:
         profile: minimal
         components: clippy, rustfmt
         override: true
+
     - name: Version
       run: |
         rustup --version
         cargo --version
         cargo clippy --version
+
     - name: Build
       run: cargo build --verbose
+
     - name: Test
       run: cargo test --verbose
+
     - name: Lint
       run: cargo clippy
+
     - name: Format
       run: cargo fmt -- --check
+
     - name: Package
       id: package
       if: startsWith(github.ref, 'refs/tags/')
       run: ./bin/package ${{github.ref}} ${{matrix.os}} ${{matrix.target}}
       shell: bash
+
     - name: Publish
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Use `actions/cache` to cache cargo registry, index, and build between
workflow runs.

I just added this to the Just and Intermodal repositories, and it cut build times in half,
so I thought I would add it to `qc` while I was at it.

The improvement in build times won't be visible in this PR, due to GitHub's
implementation of cache-isolation, and because the cache hasn't been
populated yet. Future PRs and merges will however, once this lands in master
and the master branch cache is populated.

I also added rules to run the build workflow on pull requests to master, like this one.